### PR TITLE
deactivate coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,13 @@ jobs:
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run: "python -m tox"
 
-      - name: "Report to coveralls"
-        # coverage is only created in the py39 environment
-        # --service=github is a workaround for bug
-        # https://github.com/coveralls-clients/coveralls-python/issues/251
-        if: "matrix.python-version == '3.9'"
-        run: |
-          pip install coveralls
-          coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: "Report to coveralls"
+      #   # coverage is only created in the py39 environment
+      #   # --service=github is a workaround for bug
+      #   # https://github.com/coveralls-clients/coveralls-python/issues/251
+      #   if: "matrix.python-version == '3.9'"
+      #   run: |
+      #     pip install coveralls
+      #     coveralls --service=github
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,6 @@
    :target: https://github.com/morepath/more.body_model/actions?workflow=CI
    :alt: CI Status
 
-.. image:: https://coveralls.io/repos/github/morepath/more.body_model/badge.svg?branch=master
-    :target: https://coveralls.io/github/morepath/more.body_model?branch=master
-
 .. image:: https://img.shields.io/pypi/v/more.body_model.svg
   :target: https://pypi.org/project/more.body_model/
 


### PR DESCRIPTION
For unknown reasons the coveralls.io integration does not work for this
repository, but for most of the others.

It fails with a
coveralls.exception.CoverallsException: Could not submit coverage: 422 Client Error: Unprocessable Entity for url: https://coveralls.io/api/v1/jobs

As we have 100% test coverage anyway, we can deactivate coveralls.io
integration and just fail when coverage goes below 100%.

fixes #5 

modified:   .github/workflows/main.yml